### PR TITLE
Add an extra 1024MB of ram to facilitate data loading

### DIFF
--- a/playbooks/Vagrantfile
+++ b/playbooks/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider "virtualbox" do |vb|
     vb.gui = false
-    vb.memory = "1024"
+    vb.memory = "2048"
   end
 
   # Fix the annoyance from https://github.com/mitchellh/vagrant/issues/1673


### PR DESCRIPTION
Initial allocation of 1024MB was not sufficient when performing data load in the vagrant box
