### PR TITLE
Add static folder to rsync-filter

### DIFF
--- a/.rsync-filter
+++ b/.rsync-filter
@@ -3,6 +3,8 @@
 - .tox/
 - htmlcov/
 - *.egg-info/
+- static/*
++ static/.gitkeep
 - .coverage
 - *.pyc
 - *.pyo


### PR DESCRIPTION
This excludes static files from dev machine from being rsync'd to server
